### PR TITLE
Feature/django18

### DIFF
--- a/beproud/django/notify/models.py
+++ b/beproud/django/notify/models.py
@@ -51,7 +51,6 @@ class Notification(models.Model):
     class Meta:
         ordering = ('-ctime',)
 
-
 class NotifySetting(models.Model):
     target_content_type = models.ForeignKey(ContentType, verbose_name=_('content type id'))
     target_object_id = models.PositiveIntegerField(_('target id'))
@@ -59,7 +58,7 @@ class NotifySetting(models.Model):
 
     notify_type = models.CharField(_('notify type'), max_length=100, db_index=True)
     media = models.CharField(_('media'), max_length=100, choices=MediaChoices(), db_index=True)
-    send = models.BooleanField(_('send?'))
+    send = models.BooleanField(_('send?'), default=True)
 
     def __unicode__(self):
         return u"%s (%s, %s, %s)" % (self.target, self.notify_type, self.media,

--- a/beproud/django/notify/models.py
+++ b/beproud/django/notify/models.py
@@ -51,6 +51,7 @@ class Notification(models.Model):
     class Meta:
         ordering = ('-ctime',)
 
+
 class NotifySetting(models.Model):
     target_content_type = models.ForeignKey(ContentType, verbose_name=_('content type id'))
     target_object_id = models.PositiveIntegerField(_('target id'))

--- a/beproud/django/notify/models.py
+++ b/beproud/django/notify/models.py
@@ -59,7 +59,7 @@ class NotifySetting(models.Model):
 
     notify_type = models.CharField(_('notify type'), max_length=100, db_index=True)
     media = models.CharField(_('media'), max_length=100, choices=MediaChoices(), db_index=True)
-    send = models.BooleanField(_('send?'), default=True)
+    send = models.BooleanField(_('send?'), default=False)
 
     def __unicode__(self):
         return u"%s (%s, %s, %s)" % (self.target, self.notify_type, self.media,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bpnotify',
-    version='0.44',
+    version='0.45',
     description='Notification routing for Django',
     author='Ian Lewis',
     author_email='ian@beproud.jp',

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ setup(
     name='bpnotify',
     version='0.45',
     description='Notification routing for Django',
-    author='Ian Lewis',
-    author_email='ian@beproud.jp',
+    author='BeProud',
+    author_email='project@beproud.jp',
     url='https://github.com/beproud/bpnotify/',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
django1.8で BooleanField に default 引数が無いとwarningを出すので defualt=False を追加しました。

NotifySetting.send=Trueだと対象オブジェクトは通知される動きになります。

テストではデフォルトで NotifySettings.send = False のような動きを想定しているようなのでFalseにしちゃいました