### PR TITLE
Add django2.2 support and drop django1.8 #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "2.7"
   - "3.6"
 env:
-  - DJANGO="1.8"
   - DJANGO="1.11"
+  - DJANGO="2.2"
 script: tox

--- a/beproud/django/notify/models.py
+++ b/beproud/django/notify/models.py
@@ -33,7 +33,8 @@ class NotificationManager(models.Manager):
 @six.python_2_unicode_compatible
 class Notification(models.Model):
     target_content_type = models.ForeignKey(ContentType, verbose_name=_('content type id'),
-                                            db_index=True, null=True, blank=True)
+                                            db_index=True, null=True, blank=True,
+                                            on_delete=models.CASCADE)
     target_object_id = models.PositiveIntegerField(_('target id'),
                                                    db_index=True, null=True, blank=True)
     target = GenericForeignKey('target_content_type', 'target_object_id')
@@ -56,7 +57,7 @@ class Notification(models.Model):
 
 @six.python_2_unicode_compatible
 class NotifySetting(models.Model):
-    target_content_type = models.ForeignKey(ContentType, verbose_name=_('content type id'))
+    target_content_type = models.ForeignKey(ContentType, verbose_name=_('content type id'), on_delete=models.CASCADE)
     target_object_id = models.PositiveIntegerField(_('target id'))
     target = GenericForeignKey('target_content_type', 'target_object_id')
 

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,5 @@ setup(
         'django-jsonfield>=1.0.1',
         'six',
     ],
-    tests_require=[
-        'celery~=4.2.2',
-        'mock>=0.7.2',
-    ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_file(filename):
 
 setup(
     name='bpnotify',
-    version='0.46',
+    version='0.47',
     description='Notification routing for Django',
     author='BeProud',
     author_email='project@beproud.jp',
@@ -35,12 +35,12 @@ setup(
     namespace_packages=['beproud', 'beproud.django'],
     test_suite='tests.main',
     install_requires=[
-        'Django>=1.8',
+        'Django>=1.11',
         'django-jsonfield>=1.0.1',
         'six',
     ],
     tests_require=[
-        'celery>=4.1',
+        'celery~=4.2.2',
         'mock>=0.7.2',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27-django{18,111},py36-django{18,111}
+envlist = py27-django{111,22},py36-django{111,22}
 
 [testenv]
 basepython =
@@ -9,21 +9,21 @@ basepython =
 
 deps =
     six
-    django18: Django>=1.8,<1.9
-    django18: celery>=4.0,<4.1
     django111: Django>=1.11,<2.0
-    django111: celery>=4.0,<4.1
+    django111: celery>=4.2,<4.3
+    django22: Django~=2.2.12
+    django22: celery>=4.2,<4.3
 
 commands=python setup.py test
 
 [travis]
 os =
-  linux: py{27,36}-django{18,111}
+  linux: py{27,36}-django{111,22}
 python =
   2.7: py27
   3.6: py36
 
 [travis:env]
 DJANGO =
-  1.8: django18
   1.11: django111
+  2.2: django22

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,13 @@ deps =
     django111: celery>=4.2,<4.3
     django22: Django~=2.2.12
     django22: celery>=4.2,<4.3
+    mock>=0.7.2
 
 commands=python setup.py test
 
 [travis]
 os =
-  linux: py{27,36}-django{111,22}
+  linux: py27-django111, py36-django{111,22}
 python =
   2.7: py27
   3.6: py36


### PR DESCRIPTION
#12 の対応。

Django1.9 で deprecated & 2.0 で required となった以下を修正

ForeignKey and OneToOneField on_delete argument
https://docs.djangoproject.com/en/2.2/releases/1.9/#foreignkey-and-onetoonefield-on-delete-argument

ついでに Django1.8 のサポートを切り捨てました。